### PR TITLE
Fix: Remove payment creation on new receivable

### DIFF
--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -57,16 +57,10 @@ class Customer extends Model
         $this->increment('total_receivables', $amount);
         $this->update(['last_transaction_date' => now()]);
 
-        // تسجيل فاتورة المبيعات كمعاملة
-        Payment::create([
-            'customer_id' => $this->id,
-            'amount' => $amount,
-            'payment_date' => now(),
-            'type' => 'invoice', // A receivable is an invoice
-            'reference' => $referenceType,
-            'notes' => $description ?? 'فاتورة مبيعات آجلة',
-            'created_by' => auth()->id(),
-        ]);
+        // The creation of a receivable is not a payment event.
+        // A payment record should only be created when a customer actually pays.
+        // The sales order or invoice itself represents the debt.
+        // By removing this, we prevent the CHECK constraint violation.
     }
 
     public function addPayment($amount, $description = null, $referenceType = null, $referenceId = null)


### PR DESCRIPTION
Fixes a SQLSTATE[23000] Integrity constraint violation that occurred when creating a credit sale.

The error was caused by the `addReceivable` method in the Customer model attempting to create a `Payment` record with a type of 'invoice'. This violated a database ENUM constraint on the `payments.type` column, which only allows 'receipt' or 'disbursement'.

The creation of a receivable is an accounting event, not a payment event. The `Payment` record should only be created when a customer makes an actual payment.

This commit removes the erroneous `Payment::create()` call from the `addReceivable` method, resolving the constraint violation.