### PR TITLE
Fix: Correct sales order logic by altering payments schema

### DIFF
--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -57,10 +57,16 @@ class Customer extends Model
         $this->increment('total_receivables', $amount);
         $this->update(['last_transaction_date' => now()]);
 
-        // The creation of a receivable is not a payment event.
-        // A payment record should only be created when a customer actually pays.
-        // The sales order or invoice itself represents the debt.
-        // By removing this, we prevent the CHECK constraint violation.
+        // تسجيل فاتورة المبيعات كمعاملة
+        Payment::create([
+            'customer_id' => $this->id,
+            'amount' => $amount,
+            'payment_date' => now(),
+            'type' => 'invoice', // This will now be valid after the migration
+            'reference' => $referenceType,
+            'notes' => $description ?? 'فاتورة مبيعات آجلة',
+            'created_by' => auth()->id(),
+        ]);
     }
 
     public function addPayment($amount, $description = null, $referenceType = null, $referenceId = null)

--- a/database/migrations/2025_08_19_142300_alter_payments_table_for_type.php
+++ b/database/migrations/2025_08_19_142300_alter_payments_table_for_type.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            // Change the 'type' column from ENUM to a more flexible STRING
+            // This allows for more transaction types like 'invoice'
+            $table->string('type')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            // Reverting back to ENUM is tricky as data might be lost.
+            // For this rollback, we'll assume only the original values are wanted.
+            // A better approach in a real project might be to check existing data.
+            $table->enum('type', ['receipt', 'disbursement'])->change();
+        });
+    }
+};


### PR DESCRIPTION
This commit addresses multiple reported issues related to sales order processing, including cash sales being recorded as credit and credit sales not updating customer balances.

The root cause was determined to be a conflict between the application logic, which attempted to log invoice creation in the `payments` table, and a restrictive `ENUM` constraint on the `payments.type` column in the database.

The fix involves two parts:
1.  The `addReceivable` method in `Customer.php` is restored to create a `Payment` record of type 'invoice'. This ensures that the application's expectation of a transaction log is met, which likely resolves the cascading logical errors.
2.  A new migration is added (`...alter_payments_table_for_type.php`) to change the `payments.type` column from a restrictive ENUM to a more flexible VARCHAR. This allows the 'invoice' type to be saved, preventing the database constraint violation.

This approach fixes the database error while preserving the application's intended transaction logging behavior, which should resolve the reported logical bugs.